### PR TITLE
解决Observed注解的参数无法被modelToValuesBucket处理的问题，以及自增参数被赋值后不能自增的问题。

### DIFF
--- a/rdbstore/src/main/ets/compile/SqlCompiler.ets
+++ b/rdbstore/src/main/ets/compile/SqlCompiler.ets
@@ -136,7 +136,7 @@ export namespace SqlCompiler {
             columnBindValue(values, property, innerTargetModel)
           }
         } else {
-          if (entity[property.name] != undefined) {
+          if (entity[property.name] != undefined && !property.autoincrement) {
             columnBindValue(values, property, entity)
           }
         }
@@ -144,7 +144,6 @@ export namespace SqlCompiler {
     }
     return values
   }
-
 
   /**
    * 批量完成查询结果解析

--- a/rdbstore/src/main/ets/decoration/Column.ets
+++ b/rdbstore/src/main/ets/decoration/Column.ets
@@ -30,6 +30,7 @@ export function Columns(info: ColumnInfo): PropertyDecorator {
     const columnMeta: object = target[RdbConst.COLUMN] ?? new Object
     if ((typeof propertyKey === 'string')) {
       columnMeta[propertyKey] = info
+      columnMeta["__ob_" + propertyKey] = info
     }
     target[RdbConst.COLUMN] = columnMeta
   };


### PR DESCRIPTION
在使用中，我在@ObservedV2的类中使用了@Columns构建数据库，发现使用了@Trace装饰的属性无法解析到数据库数据中；以及自增参数，如果我填了值，则不会再自增。